### PR TITLE
tebeka/strftime from Github instead of Bitbucket

### DIFF
--- a/rotatelogs.go
+++ b/rotatelogs.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"bitbucket.org/tebeka/strftime"
+	"github.com/tebeka/strftime"
 )
 
 func (c clockFn) Now() time.Time {


### PR DESCRIPTION
@lestrrat 

I find that Miki Tebeka had already imported his projects into Github

and the strftime for golang is here: https://github.com/tebeka/strftime

it would be easier for people to install rotatelogs without install the HG