### PR TITLE
fix: set default maxAge by 7 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Note: Remember to use time.Duration values.
   )
 ```
 
-## MaxAge (default: 0)
+## MaxAge (default: 7 days)
 
 Time to wait until old logs are purged. By default no logs are purged, which
 certainly isn't what you want.

--- a/rotatelogs.go
+++ b/rotatelogs.go
@@ -99,6 +99,7 @@ func New(pattern string, options ...Option) (*RotateLogs, error) {
 	rl.globPattern = globPattern
 	rl.pattern = strfobj
 	rl.rotationTime = 24 * time.Hour
+	rl.maxAge = 7 * 24 * time.Hour
 	for _, opt := range options {
 		opt.Configure(&rl)
 	}


### PR DESCRIPTION
In the current version, default `maxAge` as 0 will failed when rotate:

Soure:

```
rl, _ := rotatelogs.NewRotateLogs("/path/to/access_log.%Y%m%d%H%M")
```

Output:
```
failed to rotate: maxAge not set, not rotating
```
Breaking line:

https://github.com/lestrrat/go-file-rotatelogs/blob/master/rotatelogs.go#L237

Thie PR will fix this by add a default value in `New` method.
