### PR TITLE
Support rotationCount option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,18 @@ Note: Remember to use time.Duration values.
     rotatelogs.WithMaxAge(time.Hour),
   )
 ```
+
+## RotationCount (default: -1)
+
+The number of files should be kept. By default, this option is disabled.
+
+Note: MaxAge should be disabled by specifing `WithMaxAge(-1)` explicitly.
+
+```go
+  // Purge logs except latest 7 files
+  rotatelogs.New(
+    "/var/log/myapp/log.%Y%m%d",
+    rotatelogs.WithMaxAge(-1),
+    rotatelogs.WithRotationCount(7),
+  )
+```

--- a/interface.go
+++ b/interface.go
@@ -11,15 +11,16 @@ import (
 // RotateLogs represents a log file that gets
 // automatically rotated as you write to it.
 type RotateLogs struct {
-	clock        Clock
-	curFn        string
-	globPattern  string
-	linkName     string
-	maxAge       time.Duration
-	mutex        sync.RWMutex
-	outFh        *os.File
-	pattern      *strftime.Strftime
-	rotationTime time.Duration
+	clock         Clock
+	curFn         string
+	globPattern   string
+	linkName      string
+	maxAge        time.Duration
+	mutex         sync.RWMutex
+	outFh         *os.File
+	pattern       *strftime.Strftime
+	rotationTime  time.Duration
+	rotationCount int
 }
 
 // Clock is the interface used by the RotateLogs


### PR DESCRIPTION
It is useful if count of rotation option is also supported.
To keep compatibility, `maxAge` is still required option.
`rotationCount` overrides `maxAge` option if it is specified.