### PR TITLE
README: Fix the code example to use the v2 API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ import(
 )
   
 func main() {
-  rl, _ := rotatelogs.NewRotateLogs("/path/to/access_log.%Y%m%d%H%M")
+  rl, _ := rotatelogs.New("/path/to/access_log.%Y%m%d%H%M")
 
   log.SetOutput(rl)
 


### PR DESCRIPTION
### What is this patch?

For now, the code example in README.md does not work because it relies on
the old API (which has been deprecated since v2.0.0).

This small patch fixes this issue by migrating the code to use the newer interface.
With this patch applied, the code example will work fine.